### PR TITLE
Add functionality to collapse card when another one is open

### DIFF
--- a/src/containers/CollapsibleCard.tsx
+++ b/src/containers/CollapsibleCard.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC } from "react";
 
 import { ChevronDown, ChevronUp } from "../assets/icons";
 import { Card } from "../components";
@@ -8,12 +8,17 @@ import { ICollapsibleCard } from "../types/card";
 import { Content } from "./Content";
 import { CollapsibleCardWrapper, CollapsibleTitleWrapper } from "./styles";
 
-export const CollapsibleCard: FC<ICollapsibleCard> = ({ dashboardTitle, id }) => {
-	const [isCollapsed, setIsCollapsed] = useState(true);
+export const CollapsibleCard: FC<ICollapsibleCard> = ({
+	dashboardTitle,
+	id,
+	setOpenCardId,
+	openCardId,
+}) => {
 	const { dashboardData } = useGetDashboard(id);
+	const isCollapsed = openCardId !== id;
 
 	const toggleCollapse = (): void => {
-		setIsCollapsed(!isCollapsed);
+		setOpenCardId(isCollapsed ? id : null);
 	};
 
 	return (

--- a/src/containers/Content.tsx
+++ b/src/containers/Content.tsx
@@ -1,6 +1,6 @@
 import { SmallTextIcon, SmallVisualIcon, SmallWorldIcon } from "../assets/icons";
 import { IDashboardItem } from "../types";
-import { ContentList } from "./styles/ContentStyles";
+import { ContentList, Divider } from "./styles/ContentStyles";
 
 const removeFirstWord = (word: string): string => {
 	const index = word.indexOf(":");
@@ -20,20 +20,29 @@ export const Content = ({ items }: { items: IDashboardItem[] }) => {
 				<li key={item.id}>
 					{item.visualization && item.visualization.name && (
 						<>
-							<SmallVisualIcon />
-							{removeFirstWord(item.visualization.name)}
+							<>
+								<SmallVisualIcon />
+								{removeFirstWord(item.visualization.name)}
+							</>
+							<Divider />
 						</>
 					)}
 					{item.map && item.map.name && (
 						<>
-							<SmallWorldIcon />
-							{removeFirstWord(item.map.name)}
+							<>
+								<SmallWorldIcon />
+								{removeFirstWord(item.map.name)}
+							</>
+							<Divider />
 						</>
 					)}
 					{item.text && (
 						<>
-							<SmallTextIcon />
-							{item.text}
+							<>
+								<SmallTextIcon />
+								{item.text}
+							</>
+							<Divider />
 						</>
 					)}
 				</li>

--- a/src/containers/styles/ContentStyles.tsx
+++ b/src/containers/styles/ContentStyles.tsx
@@ -1,14 +1,21 @@
 import styled from "styled-components";
 
 export const ContentList = styled.ul`
+	padding: 0 20px 0 20px;
+
 	li {
 		font-size: 12px;
 		list-style-type: none;
-		margin-left: 25px;
 	}
 
 	svg {
 		margin-right: 8px;
 		vertical-align: middle;
 	}
+`;
+
+export const Divider = styled.hr`
+	background-color: #e9e3e3;
+	border: none;
+	height: 0.75px;
 `;

--- a/src/pages/DashboardPage.test.tsx
+++ b/src/pages/DashboardPage.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-mocks-import */
 import { render, screen } from "@testing-library/react";
 
 import { mockedDashboards } from "../../tests/fixtures/index";

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,17 +1,28 @@
+import { useEffect, useState } from "react";
+
 import { CollapsibleCard } from "../containers/CollapsibleCard";
+import { Divider } from "../containers/styles";
 import { useGetDashboards } from "../hooks/useGetDashboards";
 
 export const DashboardPage = () => {
 	const { dashboards, loading } = useGetDashboards();
+	const [openCardId, setOpenCardId] = useState<string | null>(null);
 
-	return !loading ? (
+	useEffect(() => {
+		setOpenCardId(dashboards[0]?.id);
+	}, [dashboards]);
+
+	return !loading && dashboards.length > 0 ? (
 		<>
+			<Divider />
 			{dashboards.map((dashboard) => {
 				return (
 					<CollapsibleCard
 						key={dashboard.id}
 						dashboardTitle={dashboard.displayName}
 						id={dashboard.id}
+						openCardId={openCardId}
+						setOpenCardId={setOpenCardId}
 					/>
 				);
 			})}

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -6,4 +6,6 @@ export interface ICard {
 export interface ICollapsibleCard {
 	dashboardTitle: string;
 	id: string;
+	openCardId: string | null;
+	setOpenCardId: (id: string | null) => void;
 }


### PR DESCRIPTION
## Feature description

Add functionality to close a card when another one is open.
Add functionality to open the first card when the page is rendered.

## Summary changes

- Update Collapsible Card with props to collapse when the id is different.
- Update styles.
