### PR TITLE
Add event propagation to avoid clicking on favorite

### DIFF
--- a/src/containers/CollapsibleCard.tsx
+++ b/src/containers/CollapsibleCard.tsx
@@ -29,13 +29,14 @@ export const CollapsibleCard: FC<ICollapsibleCard> = ({
 		setOpenCardId(isCollapsed ? id : null);
 	};
 
-	const toggleFavorite = () => {
+	const toggleFavorite = (event: React.MouseEvent) => {
+		event.stopPropagation();
 		setFavorite(!isFavorite);
 		localStorage.setItem(dashboardTitle, !isFavorite ? "favorite" : "");
 	};
 
 	return (
-		<CollapsibleCardWrapper>
+		<CollapsibleCardWrapper onClick={toggleCollapse}>
 			<Card>
 				<CollapsibleTitleWrapper>
 					<h6>{dashboardTitle}</h6>


### PR DESCRIPTION
## Feature description

The card should be clickable in order to be opened except when clicking on the Star icon.

## Summary changes

- Add event stop propagation to toggleFavorite function.

